### PR TITLE
A more robust parse method

### DIFF
--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -5,15 +5,20 @@ function Base.parse(::Type{Decimal}, str::AbstractString)
     # Unpack scientific notation
     scno = split(str, 'e')
     expo = length(scno) == 2 ? parse(Int64, scno[2]) : zero(Int64)
-    # Unpack coefficient and get fractional part
+    # Unpack coefficient and get integer/fractional parts
     coef = split(scno[1], '.')
+    intp = lstrip(coef[1], ('+', '-', '0'))
     frac = length(coef) == 2 ? rstrip(coef[2], '0') : ""
     # Update exponent
     if length(frac) == 0
-        c = rstrip(coef[1], '0')
-        expo += length(coef[1]) - length(c)
+        if length(intp) == 0
+            return Decimal(s, zero(BigInt), zero(Int64))
+        else
+            c = rstrip(intp, '0')
+            expo += length(intp) - length(c)
+        end
     else
-        c = coef[1] * frac
+        c = intp * frac
         expo -= length(frac)
     end
     Decimal(s, abs(parse(BigInt, c)), expo)

--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -1,10 +1,22 @@
 # Convert a string to a decimal, e.g. "0.01" -> Decimal(0, 1, -2)
 function Base.parse(::Type{Decimal}, str::AbstractString)
-    if 'e' in str
-        return parse(Decimal, scinote(str))
+    # Read sign
+    s = (str[1] == '-') ? 1 : 0
+    # Unpack scientific notation
+    scno = split(str, 'e')
+    expo = length(scno) == 2 ? parse(Int64, scno[2]) : zero(Int64)
+    # Unpack coefficient and get fractional part
+    coef = split(scno[1], '.')
+    frac = length(coef) == 2 ? rstrip(coef[2], '0') : ""
+    # Update exponent
+    if length(frac) == 0
+        c = rstrip(coef[1], '0')
+        expo += length(coef[1]) - length(c)
+    else
+        c = coef[1] * frac
+        expo -= length(frac)
     end
-    c, q = parameters(('.' in str) ? split(str, '.') : str)
-    normalize(Decimal((str[1] == '-') ? 1 : 0, c, q))
+    Decimal(s, abs(parse(BigInt, c)), expo)
 end
 
 decimal(str::AbstractString) = parse(Decimal, str)
@@ -17,32 +29,6 @@ Decimal(num::Real) = parse(Decimal, string(num))
 Base.convert(::Type{Decimal}, num::Real) = Decimal(num::Real)
 decimal(x::Real) = Decimal(x)
 Decimal(x::Decimal) = x
-
-# Get Decimal constructor parameters from string
-parameters(x::AbstractString) = (abs(parse(BigInt, x)), 0)
-
-# Get Decimal constructor parameters from array
-function parameters(x::Array)
-    c = parse(BigInt, join(x))
-    (abs(c), -length(x[2]))
-end
-
-# Get decimal() argument from scientific notation
-function scinote(str::AbstractString)
-    s = (str[1] == '-') ? "-" : ""
-    n, expo = split(str, 'e')
-    n = split(n, '.')
-    if s == "-"
-        n[1] = n[1][2:end]
-    end
-    if parse(Int64, expo) > 0
-        shift = parse(Int64, expo) - ((length(n) == 2) ? length(n[2]) : 0)
-        s * join(n) * repeat("0", shift)
-    else
-        shift = -parse(Int64, expo) - ((length(n) == 2) ? length(n[1]) : length(n))
-        s * "0." * repeat("0", shift) * join(n)
-    end
-end
 
 # Convert a decimal to a string
 function Base.print(io::IO, x::Decimal)

--- a/test/test_decimal.jl
+++ b/test/test_decimal.jl
@@ -40,6 +40,9 @@ using Compat.Test
         @test parse(Decimal, "-0012.3450") == Decimal(-12.345) == Decimal(1, 12345, -3)
         @test parse(Decimal, "0012.3450e3") == parse(Decimal, "+0012.3450e3") == Decimal(12.345e3) == Decimal(0, 12345, 0)
         @test parse(Decimal, "-0012.3450e-3") == Decimal(-12.345e-3) == Decimal(1, 12345, -6)
+
+        @test_throws ArgumentError parse(Decimal, "1.2.3")
+        @test_throws ArgumentError parse(Decimal, "1e2e3")
     end
 
     @testset "Using `decimal`" begin

--- a/test/test_decimal.jl
+++ b/test/test_decimal.jl
@@ -31,7 +31,15 @@ using Compat.Test
         @test parse(Decimal, "1.0000001e6") == Decimal(1.0000001e6) == Decimal(0, 10000001, -1)
         @test parse(Decimal, "30e-2") == Decimal(30e-2) == Decimal(0, 3, -1)
         @test parse(Decimal, "0.1234567e-15") == Decimal(0.1234567e-15) == Decimal(0, 1234567, -22)
-        @test parse(Decimal, "123456789.1234567899e-11") == Decimal(123456789.1234567899e-11) == Decimal(0, 1234567891234567899, -21)
+        @test parse(Decimal, "123456789.1234567899e-11") == Decimal(0, 1234567891234567899, -21)
+
+        @test parse(Decimal, "0.0") == Decimal(0) == Decimal(0.0) == Decimal(0, 0, 0)
+        @test parse(Decimal, "-0.0") == Decimal(-0.0) == Decimal(1, 0, 0)
+        
+        @test parse(Decimal, "0012.3450") == parse(Decimal, "+0012.3450") == Decimal(12.345) == Decimal(0, 12345, -3)
+        @test parse(Decimal, "-0012.3450") == Decimal(-12.345) == Decimal(1, 12345, -3)
+        @test parse(Decimal, "0012.3450e3") == parse(Decimal, "+0012.3450e3") == Decimal(12.345e3) == Decimal(0, 12345, 0)
+        @test parse(Decimal, "-0012.3450e-3") == Decimal(-12.345e-3) == Decimal(1, 12345, -6)
     end
 
     @testset "Using `decimal`" begin

--- a/test/test_decimal.jl
+++ b/test/test_decimal.jl
@@ -27,6 +27,11 @@ using Compat.Test
 
         @test parse(Decimal, "0.1234567891") == Decimal(0.1234567891) == Decimal(0,1234567891, -10)
         @test parse(Decimal, "0.12345678912") == Decimal(0.12345678912) == Decimal(0,12345678912, -11)
+
+        @test parse(Decimal, "1.0000001e6") == Decimal(1.0000001e6) == Decimal(0, 10000001, -1)
+        @test parse(Decimal, "30e-2") == Decimal(30e-2) == Decimal(0, 3, -1)
+        @test parse(Decimal, "0.1234567e-15") == Decimal(0.1234567e-15) == Decimal(0, 1234567, -22)
+        @test parse(Decimal, "123456789.1234567899e-11") == Decimal(123456789.1234567899e-11) == Decimal(0, 1234567891234567899, -21)
     end
 
     @testset "Using `decimal`" begin


### PR DESCRIPTION
The current implementation of the parse method for the Decimal type cannot handle correctly cases such as "1.0000001e6", "30e-2", "0.1234567e-15" or "123456789.1234567899e-11".
I wrote a replacement proposal that handles these cases. It does not treat scientific notation as a separate case, so the function scinote (and the parameters functions) are no longer used.