### PR TITLE
Add a show method for pretty printing of Decimals

### DIFF
--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -84,3 +84,6 @@ end
 @deprecate isint(x::Integer) isinteger(x)
 @deprecate isint(x::AbstractFloat) isinteger(x)
 @deprecate isint(x::AbstractString) isinteger(parse(Float64, x))
+
+# Overload Base.show to make Decimals easier to read
+Base.show(io::IO, d::Decimal) = print(io, string(d))


### PR DESCRIPTION
Currently there's not a `Base.show` method for the `Decimal` type.  This makes them hard to read on the repl, in notebooks, and in DataFrames.  