### PR TITLE
Fix Julia compat for patch release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "abce61dc-4473-55a0-ba07-351d65e31d42"
 version = "0.4.1"
 
 [compat]
-julia = "1"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Patch release should not narrow the range of supported Julia versions.