### PR TITLE
Support tryparse

### DIFF
--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -10,7 +10,8 @@ end
 # Support for tryparse: useful also for integration with other packages, e.g. CSVFiles.jl, Parsers.jl
 function Base.tryparse(::Type{Decimal}, str::AbstractString)
     if 'e' in str
-        return tryparse(Decimal, _scinote_internal(str))
+        sci = @something _scinote_internal(str) return
+        return tryparse(Decimal, sci)
     end
     c, q = @something _parameters_internal(('.' in str) ? split(str, '.') : str) return
     normalize(Decimal((str[1] == '-') ? 1 : 0, c, q))

--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -1,9 +1,18 @@
+@noinline function _parse_failure(T, str::AbstractString)
+    throw(ArgumentError("cannot parse $str as $T"))
+end
+
 # Convert a string to a decimal, e.g. "0.01" -> Decimal(0, 1, -2)
 function Base.parse(::Type{Decimal}, str::AbstractString)
+    @something tryparse(Decimal, str) _parse_failure(Decimal, str)
+end
+
+# Support for tryparse: useful also for integration with other packages, e.g. CSVFiles.jl, Parsers.jl
+function Base.tryparse(::Type{Decimal}, str::AbstractString)
     if 'e' in str
-        return parse(Decimal, scinote(str))
+        return tryparse(Decimal, _scinote_internal(str))
     end
-    c, q = parameters(('.' in str) ? split(str, '.') : str)
+    c, q = @something _parameters_internal(('.' in str) ? split(str, '.') : str) return
     normalize(Decimal((str[1] == '-') ? 1 : 0, c, q))
 end
 
@@ -15,8 +24,34 @@ Base.convert(::Type{Decimal}, num::Real) = Decimal(num::Real)
 decimal(x::Real) = Decimal(x)
 Decimal(x::Decimal) = x
 
+
+function _parameters_internal(x::AbstractString)
+    c = @something tryparse(BigInt, x) return
+    abs(c), 0
+end
+
+function _parameters_internal(x::Array)
+    c = @something tryparse(BigInt, join(x)) return
+    length(x) == 2 || return
+    abs(c), -length(x[2])
+end
+
+function _parameters_internal(x::AbstractString, raise::Bool)
+    @something _parameters_internal(x) begin
+        raise && _parse_failure(Decimal, x)
+        return
+    end
+end
+
+function _parameters_internal(x::Array, raise::Bool)
+    @something _parameters_internal(x) begin
+        raise && _parse_failure(Decimal, repr(x))
+        return
+    end
+end
+
 # Get Decimal constructor parameters from string
-parameters(x::AbstractString) = (abs(parse(BigInt, x)), 0)
+parameters(x::AbstractString) = _parameters_internal(x, true)
 
 # Get Decimal constructor parameters from array
 function parameters(x::Array)
@@ -24,21 +59,33 @@ function parameters(x::Array)
     (abs(c), -length(x[2]))
 end
 
-# Get decimal() argument from scientific notation
-function scinote(str::AbstractString)
+function _scinote_internal(str::AbstractString)
     s = (str[1] == '-') ? "-" : ""
     n, expo = split(str, 'e')
     n = split(n, '.')
     if s == "-"
         n[1] = n[1][2:end]
     end
-    if parse(Int64, expo) > 0
-        shift = parse(Int64, expo) - ((length(n) == 2) ? length(n[2]) : 0)
+    expo_ = @something tryparse(Int64, expo) return
+    if expo_ > 0
+        shift = expo_ - ((length(n) == 2) ? length(n[2]) : 0)
         s * join(n) * repeat("0", shift)
     else
-        shift = -parse(Int64, expo) - ((length(n) == 2) ? length(n[1]) : length(n))
+        shift = -expo_ - ((length(n) == 2) ? length(n[1]) : length(n))
         s * "0." * repeat("0", shift) * join(n)
     end
+end
+
+function _scinote_internal(str::AbstractString, raise::Bool)
+    @something _scinote_internal(str) begin
+        raise && throw(ArgumentError("cannot parse scientific notation for $str"))
+        return
+    end
+end
+
+# Get decimal() argument from scientific notation
+function scinote(str::AbstractString)
+    _scinote_internal(str, true)
 end
 
 # Convert a decimal to a string

--- a/test/test_decimal.jl
+++ b/test/test_decimal.jl
@@ -29,6 +29,34 @@ using Test
         @test parse(Decimal, "0.12345678912") == Decimal(0.12345678912) == Decimal(0,12345678912, -11)
     end
 
+    @testset "Direct with Base.tryparse" begin
+        @test tryparse(Decimal, "0.01") == Decimal(0.01) == Decimal(0, 1, -2)
+        @test tryparse(Decimal, ".001") == Decimal(.001) == Decimal(0, 1, -3)
+        @test tryparse(Decimal, "15.23") == Decimal(15.23) == Decimal(0, 1523, -2)
+        @test tryparse(Decimal, "543") == Decimal(543) == Decimal(0, 543, 0)
+        @test tryparse(Decimal, "-345") == Decimal(-345) == Decimal(1, 345, 0)
+        @test tryparse(Decimal, "000123") == Decimal(000123) == Decimal(0, 123, 0)
+        @test tryparse(Decimal, "-00032") == Decimal(-00032) == Decimal(1, 32, 0)
+        @test tryparse(Decimal, "200100") == Decimal(200100) == Decimal(0, 2001, 2)
+        @test tryparse(Decimal, "-.123") == Decimal(-.123) == Decimal(1, 123, -3)
+        @test tryparse(Decimal, "1.23000") == Decimal(1.23000) == Decimal(0, 123, -2)
+        @test tryparse(Decimal, "4734.612") == Decimal(4734.612) == Decimal(0, 4734612, -3)
+        @test tryparse(Decimal, "541724.2") == Decimal(541724.2) == Decimal(0,5417242,-1)
+        @test tryparse(Decimal, "2.5e6") == Decimal(2.5e6) == Decimal(0, 25, 5)
+        @test tryparse(Decimal, "2.385350e8") == Decimal(2.385350e8) == Decimal(0, 238535, 3)
+        @test tryparse(Decimal, "12.3e-4") == Decimal(12.3e-4) == Decimal(0, 123, -5)
+
+        @test tryparse(Decimal, "-12.3e4") == Decimal(-12.3e4) == Decimal(1, 123, 3)
+
+        @test tryparse(Decimal, "-12.3e-4") == Decimal(-12.3e-4) == Decimal(1, 123, -5)
+
+        @test tryparse(Decimal, "0.1234567891") == Decimal(0.1234567891) == Decimal(0,1234567891, -10)
+        @test tryparse(Decimal, "0.12345678912") == Decimal(0.12345678912) == Decimal(0,12345678912, -11)
+
+        @test tryparse(Decimal, "notadecimal") === nothing
+        @test tryparse(Decimal, "1,000.00") === nothing
+    end
+
     @testset "Using `decimal`" begin
         @test decimal("1.0") == Decimal(0, 1, 0)
         @test decimal(8.1) == Decimal(0, 81, -1)


### PR DESCRIPTION
I propose these changes to support `Base.tryparse`. This can be useful also for integration with other packages, like [`CSVFiles.jl`](https://github.com/queryverse/CSVFiles.jl) or [`Parsers.jl`](https://github.com/JuliaData/Parsers.jl).