### PR TITLE
Reworked parsing & conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,71 +13,94 @@ Why is this needed?  The following code in Julia gives an answer
 In words, the binary floating point arithmetics implemented in computers has finite resolution - not all real numbers (even within the limits) can be expressed exactly. While many scientific and engineering fields can handle this behavior, it is not acceptable in fields like finance, where it's important to be able to trust that $0.30 is actually 30 cents, rather than 30.000000000000004 cents.
 
 ## Installation
+
 ```julia
 julia> Pkg.add("Decimals")
 ```
 or just `Ctrl`+`]` and
-
 ```julia
 (v1.2) pkg> add Decimals
 ```
+
 ## Usage
+
 ```julia
 julia> using Decimals
 ```
-### Creating the `Decimal` object
+
+### Construction
+
+
+`Decimal` is constructed by passing values `s`, `c`, `q` such that
+`x = (-1)^s * c * 10^q`:
+```julia
+julia> Decimal(0, 1, -1)
+0.1
+
+julia> Decimal(1, 1, -1)
+-0.1
+```
+
+
+### Parsing from string
 
 You can parse `Decimal` objects from strings:
 
 ```julia
-julia> parse(Decimal, "0.2")
-Decimal(0,2,-1)
-
-julia> parse(Decimal, "-2.5e6")
-Decimal(1,25,5)
-```
-
-You can also construct `Decimal` objects from real numbers in Julia:
-```julia
-julia> Decimal(0.1)
-Decimal(0,1,-1)
-
-julia> Decimal(-1003)
-Decimal(1, 1003, 0)
-```
-
-Or can create `Decimal` objects from either strings or numbers using `decimal`:
-
-```julia
-julia> decimal("0.2")
-Decimal(0,2,-1)
-
-julia> decimal(0.1)
-Decimal(0,1,-1)
-
-julia> decimal("-2.5e6")
-Decimal(1,25,5)
-```
-
-To convert back to a string or a number (float in this case):
-
-```julia
-julia> x = decimal("0.2");
-
-julia> string(x)
+julia> x = "0.2"
 "0.2"
 
-julia> number(x)
+julia> parse(Decimal, x)
+0.2
+
+julia> tryparse(Decimal, x)
 0.2
 ```
+Parsing support scientific notation.
 
-It is also possible to call the Decimal constructor directly, by specifying the sign (`s`), coefficient (`c`), and exponent (`q`):
+### Conversion
 
+Any real number can be converted to a `Decimal`:
 ```julia
-julia> Decimal(1,2,-2)
+julia> Decimal(0.2)
+0.2
+
+julia> Decimal(-10)
+-10
 ```
 
-The numerical value of a Decimal is given by `(-1)^s * c * 10^q`.  `s` must be 0 (positive) or 1 (negative);  `c` must be non-negative; `c` and `q` must be integers.
+A `Decimal` can be converted to numeric types that can represent it:
+```julia
+julia> Float64(Decimal(0.2))
+0.2
+
+julia> Int(Decimal(10))
+10
+
+julia> Float64(Decimal(0, 1, 512))
+ERROR: ArgumentError: cannot parse "100[...]" as Float64
+
+julia> Int(Decimal(0.4))
+ERROR: ArgumentError: invalid base 10 digit '.' in "0.4"
+```
+
+### String representation
+
+A string in the decimal form of a `Decimal` can be obtained via
+`string(::Decimal)`:
+```julia
+julia> string(Decimal(0.2))
+"0.2"
+```
+
+The 2- and 3-args methods for `show` are implemented:
+```julia
+julia> repr(Decimal(1000000.0))
+"Decimal(0, 10, 5)"
+
+julia> repr("text/plain", Decimal(1000000.0))
+"1.0E+6"
+```
 
 ### Operations
 ```julia

--- a/src/Decimals.jl
+++ b/src/Decimals.jl
@@ -5,7 +5,6 @@
 module Decimals
 
 export Decimal,
-       decimal,
        number,
        normalize
 
@@ -38,5 +37,9 @@ include("equals.jl")
 include("round.jl")
 
 include("hash.jl")
+
+include("parse.jl")
+
+include("show.jl")
 
 end

--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -1,64 +1,17 @@
-# Convert a string to a decimal, e.g. "0.01" -> Decimal(0, 1, -2)
-function Base.parse(::Type{Decimal}, str::AbstractString)
-    if 'e' ∈ str
-        return parse(Decimal, scinote(str))
-    elseif 'E' ∈ str
-        return parse(Decimal, scinote(lowercase(str)))
-    end
-    c, q = parameters(('.' in str) ? split(str, '.') : str)
-    normalize(Decimal(str[1] == '-', c, q))
-end
-
-decimal(str::AbstractString) = parse(Decimal, str)
-
-# Convert a number to a decimal
-Decimal(num::Real) = parse(Decimal, string(num))
-Base.convert(::Type{Decimal}, num::Real) = Decimal(num::Real)
-decimal(x::Real) = Decimal(x)
 Decimal(x::Decimal) = x
 
-# Get Decimal constructor parameters from string
-parameters(x::AbstractString) = (abs(parse(BigInt, x)), 0)
+# From real numbers to Decimal
+Decimal(x::Real) = parse(Decimal, string(x))
+Base.convert(::Type{Decimal}, x::Real) = Decimal(x)
 
-# Get Decimal constructor parameters from array
-function parameters(x::Array)
-    c = parse(BigInt, join(x))
-    (abs(c), -length(x[2]))
-end
+# From Decimal to numbers
+(::Type{T})(x::Decimal) where {T<:Number} = parse(T, string(x))
 
-# Get decimal() argument from scientific notation
-function scinote(str::AbstractString)
-    s = (str[1] == '-') ? "-" : ""
-    n, expo = split(str, 'e')
-    n = split(n, '.')
-    if s == "-"
-        n[1] = n[1][2:end]
-    end
-    if parse(Int64, expo) >= 0
-        shift = parse(Int64, expo) - ((length(n) == 2) ? length(n[2]) : 0)
-        s * join(n) * repeat("0", shift)
-    else
-        shift = -parse(Int64, expo) - ((length(n) == 2) ? length(n[1]) : length(n))
-        s * "0." * repeat("0", shift) * join(n)
-    end
-end
-
-# Convert a decimal to a string
-function Base.print(io::IO, x::Decimal)
-    c = string(x.c)
-    negative = (x.s == 1) ? "-" : ""
-    if x.q > 0
-        print(io, negative, c, repeat("0", x.q))
-    elseif x.q < 0
-        shift = x.q + length(c)
-        if shift > 0
-            print(io, negative, c[1:shift], ".", c[(shift+1):end])
-        else
-            print(io, negative, "0.", repeat("0", -shift), c)
-        end
-    else
-        print(io, negative, c)
-    end
+# String representation of Decimal
+function Base.string(x::Decimal)
+    io = IOBuffer()
+    show_plain(io, x)
+    return String(take!(io))
 end
 
 # Zero/one value
@@ -70,15 +23,6 @@ Base.iszero(x::Decimal) = iszero(x.c)
 # As long as we do not support Inf/NaN
 Base.isfinite(x::Decimal) = true
 Base.isnan(x::Decimal) = false
-
-# convert a decimal to any subtype of Real
-(::Type{T})(x::Decimal) where {T<:Real} = parse(T, string(x))
-
-# Convert a decimal to an integer if possible, a float if not
-function number(x::Decimal)
-    ix = (str = string(x) ; fx = parse(Float64, str); round(Int64, fx))
-    (ix == fx) ? ix : fx
-end
 
 # sign
 Base.signbit(x::Decimal) = x.s

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,0 +1,47 @@
+function Base.tryparse(::Type{Decimal}, str::AbstractString)
+    regex = Regex(string(
+        "^",
+        # Optional sign
+        "(?<sign>[+-])?",
+        # Decimal part: either 1[234].[567]  or  [.]1[234]
+        "(?<dec>(?:\\d+\\.\\d*)|(?:\\.?\\d+))",
+        # Optional exponent part: e or E followed by optional sign and digits
+        "(?<exp>[eE][+-]?\\d+)?",
+        "\$"
+    ))
+
+    m = match(regex, str)
+    if isnothing(m)
+        return nothing
+    end
+
+    sign = m[:sign]
+    deci_part = m[:dec]
+    expo_part = m[:exp]
+
+    # expo_part[1] is 'e' or 'E'
+    exponent = isnothing(expo_part) ? 0 : parse(Int, @view expo_part[2:end])
+
+    int_frac = split(deci_part, ".", keepempty=true)
+    if length(int_frac) == 1
+        # There is no decimal point
+        coef = parse(BigInt, deci_part)
+    else
+        # There is a decimal point
+        @assert length(int_frac) == 2
+        int, frac = int_frac
+        coef = parse(BigInt, int * frac)
+        exponent -= length(frac)
+    end
+
+    negative = sign == "-"
+
+    return Decimal(negative, coef, exponent)
+end
+
+function Base.parse(::Type{Decimal}, str::AbstractString)
+    x = tryparse(Decimal, str)
+    isnothing(x) && throw(ArgumentError("Invalid decimal: $str"))
+    return x
+end
+

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,0 +1,64 @@
+# Show x without using exponential notation
+function show_plain(io::IO, x::Decimal)
+    if x.s
+        print(io, '-')
+    end
+
+    if x.q ≥ 0
+        # Print coefficient and `x.q` zeros
+        print(io, x.c, repeat('0', x.q))
+    else # x.q < 0
+        coef = string(x.c)
+        coefdigits = ncodeunits(coef)
+        pointpos = -x.q # How many digits should go after the decimal point
+
+        # If there are some (non-zero) digits before the decimal point,
+        # print them, then print the decimal point, and then the digits after
+        # the decimal point
+        # Otherwise, print "0." and then print zeros so that the number of
+        # zeros plus `coefdigits` is `pointpos`
+        if pointpos < coefdigits
+            print(io, @view(coef[1:end - pointpos]), ".",
+                  @view(coef[end - pointpos + 1:end]))
+        else
+            print(io, "0.", repeat('0', pointpos - coefdigits), coef)
+        end
+    end
+end
+
+# Show x using exponential notation
+function show_exponential(io::IO, x::Decimal)
+    coef = string(x.c)
+    coefdigits = ncodeunits(coef)
+
+    if x.s
+        print(io, '-')
+    end
+
+    # If there are more than one digit,
+    # put a decimal point right after the first digit
+    if coefdigits > 1
+        print(io, coef[1], ".", @view coef[2:end])
+    else
+        print(io, coef)
+    end
+
+    adjusted_exp = x.q + coefdigits - 1
+    exp_sign = adjusted_exp > 0 ? '+' : '-'
+    print(io, "E", exp_sign, abs(adjusted_exp))
+end
+
+# Prints `x` using the scientific notation
+function scientific_notation(io::IO, x::Decimal)
+    adjusted_exp = x.q + ndigits(x.c) - 1
+
+    # Decide whether to use the exponential notation
+    if x.q ≤ 0 && adjusted_exp ≥ -6
+        show_plain(io, x)
+    else
+        show_exponential(io, x)
+    end
+end
+
+Base.show(io::IO, x::Decimal) = print(io, "Decimal($(Int(x.s)), $(x.c), $(x.q))")
+Base.show(io::IO, ::MIME"text/plain", x::Decimal) = scientific_notation(io, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,8 @@ global d = [
 include("test_arithmetic.jl")
 include("test_bigint.jl")
 include("test_constructor.jl")
+include("test_parse.jl")
+include("test_show.jl")
 include("test_decimal.jl")
 include("test_equals.jl")
 include("test_hash.jl")

--- a/test/test_arithmetic.jl
+++ b/test/test_arithmetic.jl
@@ -21,7 +21,7 @@ end
 @testset "Negation" begin
     @test -Decimal.([0.3 0.2]) == [-Decimal(0.3) -Decimal(0.2)]
     @test -Decimal(0.3) == zero(Decimal) - Decimal(0.3)
-    @test iszero(decimal(12.1) - decimal(12.1))
+    @test iszero(Decimal(12.1) - Decimal(12.1))
 end
 
 @testset "Multiplication" begin

--- a/test/test_decimal.jl
+++ b/test/test_decimal.jl
@@ -5,35 +5,25 @@ using Test
 
 @testset "String/Number to Decimal" begin
     @testset "Direct" begin
-        @test parse(Decimal, "0.01") == Decimal(0.01) == Decimal(false, 1, -2)
-        @test parse(Decimal, ".001") == Decimal(.001) == Decimal(false, 1, -3)
-        @test parse(Decimal, "15.23") == Decimal(15.23) == Decimal(false, 1523, -2)
-        @test parse(Decimal, "543") == Decimal(543) == Decimal(false, 543, 0)
-        @test parse(Decimal, "-345") == Decimal(-345) == Decimal(true, 345, 0)
-        @test parse(Decimal, "000123") == Decimal(000123) == Decimal(false, 123, 0)
-        @test parse(Decimal, "-00032") == Decimal(-00032) == Decimal(true, 32, 0)
-        @test parse(Decimal, "200100") == Decimal(200100) == Decimal(false, 2001, 2)
-        @test parse(Decimal, "-.123") == Decimal(-.123) == Decimal(true, 123, -3)
-        @test parse(Decimal, "1.23000") == Decimal(1.23000) == Decimal(false, 123, -2)
-        @test parse(Decimal, "4734.612") == Decimal(4734.612) == Decimal(false, 4734612, -3)
-        @test parse(Decimal, "541724.2") == Decimal(541724.2) == Decimal(false,5417242,-1)
-        @test parse(Decimal, "2.5e6") == Decimal(2.5e6) == Decimal(false, 25, 5)
-        @test parse(Decimal, "2.385350e8") == Decimal(2.385350e8) == Decimal(false, 238535, 3)
-        @test parse(Decimal, "12.3e-4") == Decimal(12.3e-4) == Decimal(false, 123, -5)
-
-        @test parse(Decimal, "-12.3e4") == Decimal(-12.3e4) == Decimal(true, 123, 3)
-
-        @test parse(Decimal, "-12.3e-4") == Decimal(-12.3e-4) == Decimal(true, 123, -5)
-        @test parse(Decimal, "-12.3E-4") == Decimal(true, 123, -5)
-
-        @test parse(Decimal, "0.1234567891") == Decimal(0.1234567891) == Decimal(false,1234567891, -10)
-        @test parse(Decimal, "0.12345678912") == Decimal(0.12345678912) == Decimal(false,12345678912, -11)
-    end
-
-    @testset "Using `decimal`" begin
-        @test decimal("1.0") == Decimal(false, 1, 0)
-        @test decimal(8.1) == Decimal(false, 81, -1)
-        @test decimal.(Float64.(d)) == d
+        @test Decimal(0.01) == Decimal(false, 1, -2)
+        @test Decimal(.001) == Decimal(false, 1, -3)
+        @test Decimal(15.23) == Decimal(false, 1523, -2)
+        @test Decimal(543) == Decimal(false, 543, 0)
+        @test Decimal(-345) == Decimal(true, 345, 0)
+        @test Decimal(000123) == Decimal(false, 123, 0)
+        @test Decimal(-00032) == Decimal(true, 32, 0)
+        @test Decimal(200100) == Decimal(false, 2001, 2)
+        @test Decimal(-.123) == Decimal(true, 123, -3)
+        @test Decimal(1.23000) == Decimal(false, 123, -2)
+        @test Decimal(4734.612) == Decimal(false, 4734612, -3)
+        @test Decimal(541724.2) == Decimal(false,5417242,-1)
+        @test Decimal(2.5e6) == Decimal(false, 25, 5)
+        @test Decimal(2.385350e8) == Decimal(false, 238535, 3)
+        @test Decimal(12.3e-4) == Decimal(false, 123, -5)
+        @test Decimal(-12.3e4) == Decimal(true, 123, 3)
+        @test Decimal(-12.3e-4) == Decimal(true, 123, -5)
+        @test Decimal(0.1234567891) == Decimal(false,1234567891, -10)
+        @test Decimal(0.12345678912) == Decimal(false,12345678912, -11)
     end
 end
 
@@ -65,19 +55,6 @@ end
     @test BigInt(Decimal(false, 2001, 2)) == 200100
     @test BigFloat(Decimal(true, 123, -3)) == big"-0.123"
     @test Float64(Decimal(false, 123, -2)) == 1.23
-    @test number(Decimal(false, 1, -2)) == 0.01
-    @test number(Decimal(false, 1, -3)) == 0.001
-    @test number(Decimal(false, 1523, -2)) == 15.23
-    @test number(Decimal(false, 543, 0)) == 543
-    @test number(Decimal(true, 345, 0)) == -345
-    @test number(Decimal(false, 123, 0)) == 123
-    @test number(Decimal(true, 32, 0)) == -32
-    @test number(Decimal(false, 2001, 2)) == 200100
-    @test number(Decimal(true, 123, -3)) == -0.123
-    @test number(Decimal(false, 123, -2)) == 1.23
-    @test string(Float64(Decimal(false, 543, 0))) == "543.0"
-    @test string(number(Decimal(false, 543, 0))) == "543"
-    @test string(number(Decimal(false, 543, -1))) == "54.3"
 end
 
 @testset "Number functions" begin

--- a/test/test_equals.jl
+++ b/test/test_equals.jl
@@ -31,8 +31,6 @@ end
     @test Decimal(bi) == bi
     @test bi == Decimal(bi)
 
-    @test decimal(12.1) == decimal(12.1)
-
     @test Decimal(true, 0, -1) == Decimal(false, 0, 0)
 end
 
@@ -43,7 +41,6 @@ end
     @test !(Decimal(true, 0, 1) < Decimal(true, 1, 1))
     @test Decimal(false, 2, -3) < Decimal(false, 2, 3)
     @test !(Decimal(false, 2, 3) < Decimal(false, 2, -3))
-    @test !(decimal(12.1) < decimal(12.1))
     @test !(Decimal(true, 0, -1) < Decimal(false, 0, 0))
     @test !(Decimal(false, 0, 0) < Decimal(true, 0, -1))
 end
@@ -55,7 +52,6 @@ end
     @test Decimal(1, 0, 1) > Decimal(1, 1, 1)
     @test !(Decimal(0, 2, -3) > Decimal(0, 2, 3))
     @test Decimal(0, 2, 3) > Decimal(0, 2, -3)
-    @test !(decimal(12.1) > decimal(12.1))
     @test !(Decimal(1, 0, -1) > Decimal(0, 0, 0))
     @test !(Decimal(0, 0, 0) > Decimal(1, 0, -1))
 end
@@ -67,7 +63,6 @@ end
     @test !(Decimal(1, 0, 1) <= Decimal(1, 1, 1))
     @test Decimal(0, 2, -3) <= Decimal(0, 2, 3)
     @test !(Decimal(0, 2, 3) <= Decimal(0, 2, -3))
-    @test decimal(12.1) <= decimal(12.1)
     @test Decimal(1, 0, -1) <= Decimal(0, 0, 0)
     @test Decimal(0, 0, 0) <= Decimal(1, 0, -1)
 end
@@ -79,7 +74,6 @@ end
     @test Decimal(1, 0, 1) >= Decimal(1, 1, 1)
     @test !(Decimal(0, 2, -3) >= Decimal(0, 2, 3))
     @test Decimal(0, 2, 3) >= Decimal(0, 2, -3)
-    @test decimal(12.1) >= decimal(12.1)
     @test Decimal(1, 0, -1) >= Decimal(0, 0, 0)
     @test Decimal(0, 0, 0) >= Decimal(1, 0, -1)
 end

--- a/test/test_parse.jl
+++ b/test/test_parse.jl
@@ -1,0 +1,30 @@
+@testset "Parsing" begin
+    @testset "tryparse" begin
+        @test tryparse(Decimal, "0.01") == Decimal(false, 1, -2)
+        @test tryparse(Decimal, ".001") == Decimal(false, 1, -3)
+        @test tryparse(Decimal, "15.23") == Decimal(false, 1523, -2)
+        @test tryparse(Decimal, "543") == Decimal(false, 543, 0)
+        @test tryparse(Decimal, "-345") == Decimal(true, 345, 0)
+        @test tryparse(Decimal, "000123") == Decimal(false, 123, 0)
+        @test tryparse(Decimal, "-00032") == Decimal(true, 32, 0)
+        @test tryparse(Decimal, "200100") == Decimal(false, 2001, 2)
+        @test tryparse(Decimal, "-.123") == Decimal(true, 123, -3)
+        @test tryparse(Decimal, "1.23000") == Decimal(false, 123, -2)
+        @test tryparse(Decimal, "4734.612") == Decimal(false, 4734612, -3)
+        @test tryparse(Decimal, "541724.2") == Decimal(false,5417242,-1)
+        @test tryparse(Decimal, "2.5e6") == Decimal(false, 25, 5)
+        @test tryparse(Decimal, "2.385350e8") == Decimal(false, 238535, 3)
+        @test tryparse(Decimal, "12.3e-4") == Decimal(false, 123, -5)
+        @test tryparse(Decimal, "-12.3e4") == Decimal(true, 123, 3)
+        @test tryparse(Decimal, "-12.3e-4") == Decimal(true, 123, -5)
+        @test tryparse(Decimal, "-12.3E-4") == Decimal(true, 123, -5)
+        @test tryparse(Decimal, "0.1234567891") == Decimal(false,1234567891, -10)
+        @test tryparse(Decimal, "0.12345678912") == Decimal(false,12345678912, -11)
+
+        @test isnothing(tryparse(Decimal, "1.1.1"))
+        @test isnothing(tryparse(Decimal, "1f2"))
+        @test isnothing(tryparse(Decimal, "  1"))
+        @test isnothing(tryparse(Decimal, "1e1e1"))
+        @test isnothing(tryparse(Decimal, "1-1"))
+    end
+end

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1,0 +1,23 @@
+@testset "Showing" begin
+    @testset "repr" begin
+        @test repr(Decimal(1, 2, 3)) == "Decimal(1, 2, 3)"
+    end
+
+    @testset "Scientific notation" begin
+        repr("text/plain", Decimal(0,123,0)) == "123"
+        repr("text/plain", Decimal(1,123,0)) == "-123"
+        repr("text/plain", Decimal(0,123,1)) == "1.23E+3"
+        repr("text/plain", Decimal(0,123,3)) == "1.23E+5"
+        repr("text/plain", Decimal(0,123,-1)) == "12.3"
+        repr("text/plain", Decimal(0,123,-5)) == "0.00123"
+        repr("text/plain", Decimal(0,123,-10)) == "1.23E-8"
+        repr("text/plain", Decimal(1,123,-12)) == "-1.23E-10"
+        repr("text/plain", Decimal(0,0,0)) == "0"
+        repr("text/plain", Decimal(0,0,-2)) == "0.00"
+        repr("text/plain", Decimal(0,0,2)) == "0E+2"
+        repr("text/plain", Decimal(1,0,0)) == "-0"
+        repr("text/plain", Decimal(0,5,-6)) == "0.000005"
+        repr("text/plain", Decimal(0,50,-7)) == "0.0000050"
+        repr("text/plain", Decimal(0,5,-7)) == "5E-7"
+    end
+end


### PR DESCRIPTION
This is a bigger PR. I am sorry. It started off with parsing, but then got into printing too. If it's too large to review, I will try to split it into multiple PRs.

Summary:

- **Parsing** implemented according to https://speleotrove.com/decimal/daconvs.html#refnumsyn
- `tryparse` is now available too
- **Printing** implemented via scientific notation described at https://speleotrove.com/decimal/daconvs.html#reftostr
- **Removed `number(::Decimal)`**: the function was type-unstable, returning `Float64` or `Int64` depending on the value of the Decimal. The user has the option to call `Float64(::Decimal)` or `Int64(::Decimal)` based on their need.
- **Removed `decimal(x)`**: The user can use `Decimal(x)` if `x` is a number, and `parse(Decimal, x)` or (newly) `dec"123.456"` if `x` is a string. 

Fixes #20:
```julia
julia> parse(Decimal, "3.2.1")
ERROR: ArgumentError: Invalid decimal: 3.2.1
```

Fixes #45:
```julia
# Again, decimal(::String) removed, but using parse/dec_str:
julia> parse(Decimal, "1.23456789e-13")
1.23456789E-13

julia> parse(Decimal, "1.23456789e-14")
1.23456789E-14

julia> parse(Decimal, "1.23456789e-15")
1.23456789E-15

julia> parse(Decimal, "1.23456789e-21")
1.23456789E-21
```

Fixes #53:
```julia
julia> x = 1.2345678e6
1.2345678e6

julia> Decimal(x)
1234567.8
```

Closes #21
Closes #24
Closes #55