### PR TITLE
Remove `Base.convert(::Type{Decimal}, ::Real)`

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -24,8 +24,6 @@ function Decimal(x::AbstractFloat)
     return Decimal(s, c, q)
 end
 
-Base.convert(::Type{Decimal}, x::Real) = Decimal(x)
-
 function Base.BigFloat(x::Decimal)
     y = BigFloat(x.c)
     if x.q ≥ 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,18 +3,8 @@ using Test
 
 @testset "Decimals" begin
 
-global d = [
-    Decimal(false, 2, -1)
-    Decimal(false, 1, -1)
-    Decimal(false, 100, -4)
-    Decimal(false, 1512, -2)
-    Decimal(true, 3, -2)
-    Decimal(true, 4, -6)
-]
-
 include("test_arithmetic.jl")
 include("test_bigint.jl")
-include("test_constructor.jl")
 include("test_context.jl")
 include("test_decimal.jl")
 include("test_equals.jl")

--- a/test/test_constructor.jl
+++ b/test/test_constructor.jl
@@ -1,8 +1,0 @@
-using Decimals
-using Test
-
-@testset "Decimal constructor" begin
-
-@test d isa Vector{Decimal}
-
-end

--- a/test/test_decimal.jl
+++ b/test/test_decimal.jl
@@ -2,6 +2,11 @@ using Decimals
 using Test
 
 @testset "Conversions" begin
+    @testset "Decimal to Decimal" begin
+        x = Decimal(1, 2, 3)
+        @test Decimal(x) === x
+    end
+
     @testset "$T" for T in [Float32, Float64, BigFloat]
         @test T(Decimal(T(0.0))) == T(0.0)
         @test T(Decimal(T(-0.0))) == T(-0.0)


### PR DESCRIPTION
The method is unnecessary. We define constructors from `Real`s, which is enough for the fallback `convert` method to work.

This commit also removes a useless test file.